### PR TITLE
localdev adaptions

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+DEBUG = True
+STAGE = local
+DATABASE_URL = postgres://postgres@postgres:5432/db

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /data
 /static_collected
 /node_modules
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ web:
  links:
   - "db:postgres"
  ports:
-  - "80"
+  - "8000:80"
  volumes:
   - ".:/app"
- environment:
-  DATABASE_URL: postgres://postgres@postgres:5432/db
+ command: python manage.py runserver 0.0.0.0:80
+ env_file: .env
 
 db:
  image: postgres:9.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ web:
   - "8000:80"
  volumes:
   - ".:/app"
+  - "./data:/data"
  command: python manage.py runserver 0.0.0.0:80
  env_file: .env
 


### PR DESCRIPTION
- includes a standard / default set of environment variables in `.env`
- uses Django's `runserver` instead of `uwsgi` for local development
- fixed port to 8000 since it's just too much of a hassle to use otherwise
