### PR TITLE
remove TEMPLATE_CONTEXT_PROCESSORS from example

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -17,10 +17,6 @@ INSTALLED_APPS.extend([
     # add your project specific apps here
 ])
 
-TEMPLATE_CONTEXT_PROCESSORS.extend([
-    # add your template context processors here
-])
-
 MIDDLEWARE_CLASSES.extend([
     # add your own middlewares here
 ])


### PR DESCRIPTION
This is handled differently in Django 1.9+.
An example that would work with both versions would make it overly complex.
So we're opting to keep the example file simple by just removing it.
