### PR TITLE
Upgrade to Postgres 9.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,6 @@ web:
  env_file: .env-local
 
 db:
- image: postgres:9.4
+ image: postgres:9.6
  volumes:
   - ".:/app:rw"


### PR DESCRIPTION
* AWS RDS (EU/US) now use Postgres 9.6.3
* Exoscale is on Postgres 9.5.4 but is planned to be upgraded