### PR TITLE
Add further infos to the settings.py file

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -47,4 +47,4 @@ INSTALLED_APPS.extend([
 ])
 
 # To see all the settings that have been applied in this project have a look
-# our support article: 
+# our support article: https://divio.com/docs/settings

--- a/settings.py
+++ b/settings.py
@@ -1,18 +1,50 @@
-# -*- coding: utf-8 -*-
+# This is a fairly standard Django settings file, with some special additions
+# that allow addon applications to auto-configure themselves. If it looks 
+# unfamiliar, please see our documentation:
+#
+#   http://docs.divio.com/en/latest/reference/configuration-settings-file.html
+#
+# and comments below.
+
+
+# INSTALLED_ADDONS is a list of self-configuring Divio Cloud addons - see the
+# Addons view in your project's dashboard. See also the addons directory in 
+# this project, and the INSTALLED_ADDONS section in requirements.in.
 
 INSTALLED_ADDONS = [
-    # <INSTALLED_ADDONS>  # Warning: this is auto-generated. Manual changes will be overwritten.
+    # Important: Items listed inside the next block are auto-generated.
+    # Manual changes will be overwritten.
+
+    # <INSTALLED_ADDONS>
     'aldryn-addons',
     'aldryn-django',
-    # </INSTALLED_ADDONS>'
+    'aldryn-sso',
+    # </INSTALLED_ADDONS>
 ]
+
+# Now we will load auto-configured settings for addons. See:
+#
+#   http://docs.divio.com/en/latest/reference/configuration-aldryn-config.html
+#
+# for information about how this works.
+#
+# Note that any settings you provide before the next two lines are liable to be
+# overwritten, so they should be placed *after* this section.
 
 import aldryn_addons.settings
 aldryn_addons.settings.load(locals())
 
-
-# all django settings can be altered here
+# Your own Django settings can be applied from here on. Key settings like
+# INSTALLED_APPS, MIDDLEWARE and TEMPLATES are provided in the Aldryn Django
+# addon. See:
+#
+#   http://docs.divio.com/en/latest/how-to/configure-settings.html
+#
+# for guidance on managing these settings.
 
 INSTALLED_APPS.extend([
-    # add your project specific apps here
+    # Extend the INSTALLED_APPS setting by listing additional applications here
 ])
+
+# To see all the settings that have been applied in this project have a look
+# our support article: 

--- a/settings.py
+++ b/settings.py
@@ -18,7 +18,6 @@ INSTALLED_ADDONS = [
     # <INSTALLED_ADDONS>
     'aldryn-addons',
     'aldryn-django',
-    'aldryn-sso',
     # </INSTALLED_ADDONS>
 ]
 


### PR DESCRIPTION
Our settings.py file takes a little bit of getting used-to. Some users have expressed dislike of it (“too much magic”). Others have been confused about how to use it, some have messed up their settings. Some  or worse, take one look at it and decide that we are not doing “normal” Django, and gone away. We’ve seen this in support and in workshops.
Although we have documentation describing it and explaining that really it’s a pretty standard settings, that is often too late for them. An easy fix would be to get the explanation right in front of people, in the file itself.